### PR TITLE
Fix views not being shown in the saved sort order inside folders

### DIFF
--- a/src/main/java/hudson/plugins/favoriteview/FavoriteViewsTabBarBase.java
+++ b/src/main/java/hudson/plugins/favoriteview/FavoriteViewsTabBarBase.java
@@ -1,7 +1,6 @@
 package hudson.plugins.favoriteview;
 
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
-import hudson.model.ItemGroup;
 import hudson.model.User;
 import hudson.model.View;
 import hudson.model.ViewGroup;
@@ -34,7 +33,7 @@ public interface FavoriteViewsTabBarBase {
     }
 
     default Collection<View> getViews(Collection<View> views) {
-        ItemGroup<?> itemGroup = Stapler.getCurrentRequest2().findAncestorObject(ItemGroup.class);
+        String itemFullname = getItemGroup();
         User user = User.current();
         if (user == null) {
             return views;
@@ -44,7 +43,6 @@ public interface FavoriteViewsTabBarBase {
             return views;
         }
 
-        String itemFullname = itemGroup.getFullName();
         List<String> viewsForItemGroup = property.getViewsForItemGroup(itemFullname);
 
         if (viewsForItemGroup == null) {


### PR DESCRIPTION
When inside a folder or a nested views use the viewgroup to get the views relevant for sorting. During saving the owner is calculated with a trailing `/` for folders but during reading the sorted views the item full name was used that missed the trailing `/`.

<!-- Please describe your pull request here. -->

### Testing done
Manual testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
