### PR TITLE
Add integration and unit tests for Favorite Views functionality

### DIFF
--- a/src/test/java/hudson/plugins/favoriteview/FavoriteViewsIntegrationTest.java
+++ b/src/test/java/hudson/plugins/favoriteview/FavoriteViewsIntegrationTest.java
@@ -1,0 +1,116 @@
+package hudson.plugins.favoriteview;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import hudson.model.ListView;
+import hudson.model.User;
+import hudson.views.ViewsTabBar;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class FavoriteViewsIntegrationTest {
+
+    @Test
+    void favoriteViewsTabBarIsRegisteredAsExtension(JenkinsRule j) {
+        boolean found = ViewsTabBar.all().stream().anyMatch(d -> d instanceof FavoriteViewsTabBar.DescriptorImpl);
+        assertTrue(found, "FavoriteViewsTabBar should be registered as an extension");
+    }
+
+    @Test
+    void sortableViewsTabBarIsRegisteredAsExtension(JenkinsRule j) {
+        boolean found = ViewsTabBar.all().stream().anyMatch(d -> d instanceof SortableViewsTabBar.DescriptorImpl);
+        assertTrue(found, "SortableViewsTabBar should be registered as an extension");
+    }
+
+    @Test
+    void favoriteViewsUserPropertyIsRegistered(JenkinsRule j) {
+        User user = User.getById("integrationTestUser", true);
+        FavoriteViewsUserProperty prop = user.getProperty(FavoriteViewsUserProperty.class);
+        // newInstance is called and returns a property, but isEnabled=false
+        // so it might or might not be auto-added depending on Jenkins version
+        // Either way, we should be able to add it explicitly
+        if (prop == null) {
+            FavoriteViewsUserProperty newProp = new FavoriteViewsUserProperty();
+            assertDoesNotThrow(() -> user.addProperty(newProp));
+        }
+        assertNotNull(user.getProperty(FavoriteViewsUserProperty.class));
+    }
+
+    @Test
+    void endToEndFavoriteToggle(JenkinsRule j) throws IOException {
+        // Set up the tab bar
+        FavoriteViewsTabBar tabBar = new FavoriteViewsTabBar();
+
+        // Create views
+        ListView listView = new ListView("TestView", j.jenkins);
+        j.jenkins.addView(listView);
+
+        // Create user and add property
+        User user = User.getById("favoriteUser", true);
+        FavoriteViewsUserProperty property = new FavoriteViewsUserProperty();
+        user.addProperty(property);
+
+        // Mark as favorite using the view ID format
+        String viewId = tabBar.getViewId(listView);
+        property.setFavorite(viewId, true);
+
+        assertTrue(property.isFavorite(viewId));
+
+        // Un-favorite
+        property.setFavorite(viewId, false);
+        assertFalse(property.isFavorite(viewId));
+    }
+
+    @Test
+    void viewOrderPersistsThroughUserSave(JenkinsRule j) throws IOException {
+        User user = User.getById("orderUser", true);
+        FavoriteViewsUserProperty property = new FavoriteViewsUserProperty();
+        property.setViewsForItemGroup("", java.util.Arrays.asList("Z-View", "A-View", "M-View"));
+        user.addProperty(property);
+        user.save();
+
+        // Re-fetch user and check property
+        User reloaded = User.getById("orderUser", false);
+        assertNotNull(reloaded);
+        FavoriteViewsUserProperty reloadedProp = reloaded.getProperty(FavoriteViewsUserProperty.class);
+        assertNotNull(reloadedProp);
+        assertEquals(java.util.Arrays.asList("Z-View", "A-View", "M-View"), reloadedProp.getViewsForItemGroup(""));
+    }
+
+    @Test
+    void favoritesPersistThroughUserSave(JenkinsRule j) throws IOException {
+        User user = User.getById("persistUser", true);
+        FavoriteViewsUserProperty property = new FavoriteViewsUserProperty();
+        property.setFavorite("folder/MyView", true);
+        property.setFavorite("folder/OtherView", true);
+        user.addProperty(property);
+        user.save();
+
+        // Re-fetch user
+        User reloaded = User.getById("persistUser", false);
+        assertNotNull(reloaded);
+        FavoriteViewsUserProperty reloadedProp = reloaded.getProperty(FavoriteViewsUserProperty.class);
+        assertNotNull(reloadedProp);
+        assertTrue(reloadedProp.isFavorite("folder/MyView"));
+        assertTrue(reloadedProp.isFavorite("folder/OtherView"));
+        assertFalse(reloadedProp.isFavorite("folder/NonExistent"));
+    }
+
+    @Test
+    void configureTabBarOnJenkins(JenkinsRule j) {
+        // Verify we can set the tab bar on Jenkins
+        FavoriteViewsTabBar tabBar = new FavoriteViewsTabBar();
+        j.jenkins.setViewsTabBar(tabBar);
+        assertInstanceOf(FavoriteViewsTabBar.class, j.jenkins.getViewsTabBar());
+    }
+
+    @Test
+    void configureSortableTabBarOnJenkins(JenkinsRule j) {
+        SortableViewsTabBar tabBar = new SortableViewsTabBar();
+        j.jenkins.setViewsTabBar(tabBar);
+        assertInstanceOf(SortableViewsTabBar.class, j.jenkins.getViewsTabBar());
+    }
+}

--- a/src/test/java/hudson/plugins/favoriteview/FavoriteViewsTabBarBaseTest.java
+++ b/src/test/java/hudson/plugins/favoriteview/FavoriteViewsTabBarBaseTest.java
@@ -1,0 +1,80 @@
+package hudson.plugins.favoriteview;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import hudson.model.AllView;
+import hudson.model.ListView;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class FavoriteViewsTabBarBaseTest {
+
+    @Test
+    void getOwnerNameForJenkinsRoot(JenkinsRule j) {
+        FavoriteViewsTabBar tabBar = new FavoriteViewsTabBar();
+        // Jenkins root is not an AbstractFolder, so ownerName should be empty
+        String ownerName = tabBar.getOwnerName(j.jenkins);
+        assertEquals("", ownerName);
+    }
+
+    @Test
+    void getOwnerNameForView(JenkinsRule j) throws IOException {
+        // A View used as a ViewGroup would include the view name
+        // Test that getOwnerName returns empty for plain Jenkins root
+        FavoriteViewsTabBar tabBar = new FavoriteViewsTabBar();
+        AllView allView = (AllView) j.jenkins.getView("all");
+        assertNotNull(allView);
+        // allView's owner is Jenkins itself
+        String ownerName = tabBar.getOwnerName(allView.getOwner());
+        assertEquals("", ownerName);
+    }
+
+    @Test
+    void getViewsReturnsSortedViewsViaWebClient(JenkinsRule j) throws Exception {
+        // Set up the FavoriteViewsTabBar on Jenkins
+        FavoriteViewsTabBar tabBar = new FavoriteViewsTabBar();
+        j.jenkins.setViewsTabBar(tabBar);
+
+        // Create views
+        ListView viewA = new ListView("A-View", j.jenkins);
+        ListView viewB = new ListView("B-View", j.jenkins);
+        ListView viewC = new ListView("C-View", j.jenkins);
+        j.jenkins.addView(viewA);
+        j.jenkins.addView(viewB);
+        j.jenkins.addView(viewC);
+
+        // Use a WebClient to make a real request (Stapler context is available)
+        JenkinsRule.WebClient wc = j.createWebClient();
+        HtmlPage page = wc.goTo("");
+
+        // If we got here without error, the tab bar rendered successfully
+        // with the Stapler context available
+        assertNotNull(page);
+    }
+
+    @Test
+    void viewSortingLogicWithProperty() {
+        // Test the sorting logic indirectly through FavoriteViewsUserProperty
+        FavoriteViewsUserProperty property = new FavoriteViewsUserProperty();
+        property.setViewsForItemGroup("", Arrays.asList("C-View", "A-View", "B-View"));
+
+        List<String> order = property.getViewsForItemGroup("");
+        assertNotNull(order);
+        assertEquals(3, order.size());
+        assertEquals("C-View", order.get(0));
+        assertEquals("A-View", order.get(1));
+        assertEquals("B-View", order.get(2));
+    }
+
+    @Test
+    void viewSortingLogicReturnsNullForUnknownGroup() {
+        FavoriteViewsUserProperty property = new FavoriteViewsUserProperty();
+        assertNull(property.getViewsForItemGroup("unknownGroup"));
+    }
+}

--- a/src/test/java/hudson/plugins/favoriteview/FavoriteViewsTabBarTest.java
+++ b/src/test/java/hudson/plugins/favoriteview/FavoriteViewsTabBarTest.java
@@ -1,0 +1,69 @@
+package hudson.plugins.favoriteview;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import hudson.model.AllView;
+import hudson.model.ListView;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class FavoriteViewsTabBarTest {
+
+    @Test
+    void descriptorDisplayName(JenkinsRule j) {
+        FavoriteViewsTabBar.DescriptorImpl descriptor =
+                j.jenkins.getDescriptorByType(FavoriteViewsTabBar.DescriptorImpl.class);
+        assertNotNull(descriptor);
+        assertEquals("Favorite Views", descriptor.getDisplayName());
+    }
+
+    @Test
+    void getViewIdIncludesViewName(JenkinsRule j) {
+        FavoriteViewsTabBar tabBar = new FavoriteViewsTabBar();
+        AllView allView = (AllView) j.jenkins.getView("all");
+        assertNotNull(allView);
+
+        String viewId = tabBar.getViewId(allView);
+        assertTrue(viewId.endsWith(allView.getViewName()), "View ID should end with view name");
+    }
+
+    @Test
+    void isFavoriteReturnsFalseWhenNoUser(JenkinsRule j) {
+        FavoriteViewsTabBar tabBar = new FavoriteViewsTabBar();
+        AllView allView = (AllView) j.jenkins.getView("all");
+        assertNotNull(allView);
+
+        // No user logged in
+        assertFalse(tabBar.isFavorite(allView));
+    }
+
+    @Test
+    void isFavoriteReturnsFalseWhenUserHasNoProperty(JenkinsRule j) throws Exception {
+        FavoriteViewsTabBar tabBar = new FavoriteViewsTabBar();
+        AllView allView = (AllView) j.jenkins.getView("all");
+        assertNotNull(allView);
+
+        // Even after creating a user, without explicitly adding the property,
+        // isFavorite should be false (no SecurityContext set so User.current() is null)
+        assertFalse(tabBar.isFavorite(allView));
+    }
+
+    @Test
+    void getViewIdForCustomView(JenkinsRule j) throws IOException {
+        ListView listView = new ListView("MyCustomView", j.jenkins);
+        j.jenkins.addView(listView);
+
+        FavoriteViewsTabBar tabBar = new FavoriteViewsTabBar();
+        String viewId = tabBar.getViewId(listView);
+        assertTrue(viewId.contains("MyCustomView"), "View ID should contain the view name");
+    }
+
+    @Test
+    void tabBarCanBeInstantiated() {
+        FavoriteViewsTabBar tabBar = new FavoriteViewsTabBar();
+        assertNotNull(tabBar);
+    }
+}

--- a/src/test/java/hudson/plugins/favoriteview/FavoriteViewsUserPropertyDescriptorTest.java
+++ b/src/test/java/hudson/plugins/favoriteview/FavoriteViewsUserPropertyDescriptorTest.java
@@ -1,0 +1,38 @@
+package hudson.plugins.favoriteview;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import hudson.model.User;
+import hudson.model.UserProperty;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class FavoriteViewsUserPropertyDescriptorTest {
+
+    @Test
+    void descriptorDisplayName(JenkinsRule j) {
+        FavoriteViewsUserProperty.DescriptorImpl descriptor =
+                j.jenkins.getDescriptorByType(FavoriteViewsUserProperty.DescriptorImpl.class);
+        assertNotNull(descriptor);
+        assertEquals("Favorite Views", descriptor.getDisplayName());
+    }
+
+    @Test
+    void descriptorIsDisabled(JenkinsRule j) {
+        FavoriteViewsUserProperty.DescriptorImpl descriptor =
+                j.jenkins.getDescriptorByType(FavoriteViewsUserProperty.DescriptorImpl.class);
+        assertFalse(descriptor.isEnabled());
+    }
+
+    @Test
+    void newInstanceReturnsProperty(JenkinsRule j) {
+        FavoriteViewsUserProperty.DescriptorImpl descriptor =
+                j.jenkins.getDescriptorByType(FavoriteViewsUserProperty.DescriptorImpl.class);
+        User user = User.getById("testuser", true);
+        UserProperty prop = descriptor.newInstance(user);
+        assertNotNull(prop);
+        assertInstanceOf(FavoriteViewsUserProperty.class, prop);
+    }
+}

--- a/src/test/java/hudson/plugins/favoriteview/FavoriteViewsUserPropertyTest.java
+++ b/src/test/java/hudson/plugins/favoriteview/FavoriteViewsUserPropertyTest.java
@@ -1,0 +1,150 @@
+package hudson.plugins.favoriteview;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kohsuke.stapler.StaplerRequest2;
+
+class FavoriteViewsUserPropertyTest {
+
+    private FavoriteViewsUserProperty property;
+
+    @BeforeEach
+    void setUp() {
+        property = new FavoriteViewsUserProperty();
+    }
+
+    @Test
+    void isFavoriteReturnsFalseByDefault() {
+        assertFalse(property.isFavorite("someView"));
+    }
+
+    @Test
+    void setFavoriteTrueAddsView() throws IOException {
+        property.setFavorite("myView", true);
+        assertTrue(property.isFavorite("myView"));
+    }
+
+    @Test
+    void setFavoriteFalseRemovesView() throws IOException {
+        property.setFavorite("myView", true);
+        assertTrue(property.isFavorite("myView"));
+
+        property.setFavorite("myView", false);
+        assertFalse(property.isFavorite("myView"));
+    }
+
+    @Test
+    void removingNonExistentFavoriteDoesNotThrow() throws IOException {
+        assertDoesNotThrow(() -> property.setFavorite("nonExistent", false));
+        assertFalse(property.isFavorite("nonExistent"));
+    }
+
+    @Test
+    void multipleFavoritesAreIndependent() throws IOException {
+        property.setFavorite("view1", true);
+        property.setFavorite("view2", true);
+        property.setFavorite("view3", true);
+
+        assertTrue(property.isFavorite("view1"));
+        assertTrue(property.isFavorite("view2"));
+        assertTrue(property.isFavorite("view3"));
+
+        property.setFavorite("view2", false);
+
+        assertTrue(property.isFavorite("view1"));
+        assertFalse(property.isFavorite("view2"));
+        assertTrue(property.isFavorite("view3"));
+    }
+
+    @Test
+    void getViewsForItemGroupReturnsNullWhenNotSet() {
+        assertNull(property.getViewsForItemGroup("someGroup"));
+    }
+
+    @Test
+    void setAndGetViewsForItemGroup() {
+        List<String> views = Arrays.asList("view1", "view2", "view3");
+        property.setViewsForItemGroup("myGroup", views);
+
+        List<String> result = property.getViewsForItemGroup("myGroup");
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        assertEquals(Arrays.asList("view1", "view2", "view3"), result);
+    }
+
+    @Test
+    void viewOrderForDifferentItemGroupsAreIndependent() {
+        List<String> groupAViews = Arrays.asList("a1", "a2");
+        List<String> groupBViews = Arrays.asList("b1", "b2", "b3");
+
+        property.setViewsForItemGroup("groupA", groupAViews);
+        property.setViewsForItemGroup("groupB", groupBViews);
+
+        assertEquals(Arrays.asList("a1", "a2"), property.getViewsForItemGroup("groupA"));
+        assertEquals(Arrays.asList("b1", "b2", "b3"), property.getViewsForItemGroup("groupB"));
+    }
+
+    @Test
+    void overwritingViewOrderForItemGroup() {
+        property.setViewsForItemGroup("group", Arrays.asList("old1", "old2"));
+        property.setViewsForItemGroup("group", Arrays.asList("new1"));
+
+        List<String> result = property.getViewsForItemGroup("group");
+        assertEquals(1, result.size());
+        assertEquals("new1", result.get(0));
+    }
+
+    @Test
+    void readResolveInitializesNullViewOrder() throws Exception {
+        // Simulate deserialization where viewOrder could be null
+        // Use reflection to set viewOrder to null
+        var field = FavoriteViewsUserProperty.class.getDeclaredField("viewOrder");
+        field.setAccessible(true);
+        field.set(property, null);
+
+        Object result = property.readResolve();
+        assertSame(property, result);
+
+        // After readResolve, setting view order should not throw
+        assertDoesNotThrow(() -> property.setViewsForItemGroup("test", Arrays.asList("v1")));
+        assertEquals(Arrays.asList("v1"), property.getViewsForItemGroup("test"));
+    }
+
+    @Test
+    void readResolvePreservesExistingViewOrder() {
+        property.setViewsForItemGroup("group", Arrays.asList("v1", "v2"));
+
+        Object result = property.readResolve();
+        assertSame(property, result);
+
+        assertEquals(Arrays.asList("v1", "v2"), property.getViewsForItemGroup("group"));
+    }
+
+    @Test
+    void favoriteWithEmptyStringViewId() throws IOException {
+        property.setFavorite("", true);
+        assertTrue(property.isFavorite(""));
+
+        property.setFavorite("", false);
+        assertFalse(property.isFavorite(""));
+    }
+
+    @Test
+    void viewIdWithSlashesAndSpecialChars() throws IOException {
+        String viewId = "folder/subfolder$MyView";
+        property.setFavorite(viewId, true);
+        assertTrue(property.isFavorite(viewId));
+    }
+
+    @Test
+    void reconfigureReturnsSameInstance() {
+        FavoriteViewsUserProperty result =
+                (FavoriteViewsUserProperty) property.reconfigure((StaplerRequest2) null, null);
+        assertSame(property, result);
+    }
+}

--- a/src/test/java/hudson/plugins/favoriteview/SortableViewsTabBarTest.java
+++ b/src/test/java/hudson/plugins/favoriteview/SortableViewsTabBarTest.java
@@ -1,0 +1,25 @@
+package hudson.plugins.favoriteview;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class SortableViewsTabBarTest {
+
+    @Test
+    void descriptorDisplayName(JenkinsRule j) {
+        SortableViewsTabBar.DescriptorImpl descriptor =
+                j.jenkins.getDescriptorByType(SortableViewsTabBar.DescriptorImpl.class);
+        assertNotNull(descriptor);
+        assertEquals("Sortable Views", descriptor.getDisplayName());
+    }
+
+    @Test
+    void tabBarCanBeInstantiated() {
+        SortableViewsTabBar tabBar = new SortableViewsTabBar();
+        assertNotNull(tabBar);
+    }
+}


### PR DESCRIPTION
The plugin miss automated tests. As I will to activate renovate job, we need to be sure, that nothing will be broken by dependency updates.
All this tests was done by copilot and has focus to test the legacy base only.